### PR TITLE
FollowButtonに呼応するdatabase関連のfunction定義2

### DIFF
--- a/TwitterClone/API/UserService.swift
+++ b/TwitterClone/API/UserService.swift
@@ -9,6 +9,9 @@
 import Foundation
 import Firebase
 
+// 型の別名をつけることができるtypealias
+typealias DatabaseCompletion = ((Error?, DatabaseReference) -> Void)
+
 struct UserService {
     static let shared = UserService()
     
@@ -33,11 +36,19 @@ struct UserService {
         }
     }
     
-    func followUser(uid: String, completion: @escaping(Error?, DatabaseReference) -> Void){
+    func followUser(uid: String, completion: @escaping(DatabaseCompletion)){
         guard let currentUid = Auth.auth().currentUser?.uid else { return }
         
         REF_USER_FOLLOWING.child(currentUid).updateChildValues([uid: 1]) { (err, ref) in
             REF_USER_FOLLOWERS.child(uid).updateChildValues([currentUid: 1], withCompletionBlock: completion)
+        }
+    }
+    
+    func unfollowUser(uid: String, completion: @escaping(DatabaseCompletion)){
+        guard let currentUid = Auth.auth().currentUser?.uid else { return }
+        
+        REF_USER_FOLLOWING.child(currentUid).child(uid).removeValue { (err, ref) in
+            REF_USER_FOLLOWERS.child(uid).child(currentUid).removeValue(completionBlock: completion)
         }
     }
     

--- a/TwitterClone/Controllers/ProfileController.swift
+++ b/TwitterClone/Controllers/ProfileController.swift
@@ -15,7 +15,7 @@ class ProfileController: UICollectionViewController{
     
     //MARK: - Properties
     
-    private let user: User
+    private var user: User
     
     private var tweets = [Tweet]() {
         didSet { collectionView.reloadData() }
@@ -105,8 +105,19 @@ extension ProfileController: UICollectionViewDelegateFlowLayout {
 
 extension ProfileController: ProfileHeaderDelegate {
     func handleEditProfile(_ header: ProfileHeader) {
-        UserService.shared.followUser(uid: user.uid) { (ref, err) in
-            
+        
+        print("DEBUG: User is followed \(user.isFollowed) before button tap")
+        
+        if user.isFollowed {
+            UserService.shared.unfollowUser(uid: user.uid) { (err, ref) in
+                self.user.isFollowed = false
+                print("DEBUG: User is followed \(self.user.isFollowed) after button tap")
+            }
+        }else{
+            UserService.shared.followUser(uid: user.uid) { (ref, err) in
+                self.user.isFollowed = true
+                print("DEBUG: User is followed \(self.user.isFollowed) after button tap")
+            }
         }
     }
     

--- a/TwitterClone/Model/User.swift
+++ b/TwitterClone/Model/User.swift
@@ -15,6 +15,7 @@ struct User {
     let username: String
     var profileImageUrl: URL?
     let uid: String
+    var isFollowed = false
     
     var isCurrentUser: Bool { return Auth.auth().currentUser?.uid == uid }
     


### PR DESCRIPTION
followを外すためにfunctionとして、follow時にdatabaseに追加した"user-following", "user-followers"のデータをremoveする形でけした。
またここでは、お試し的にUserクラスにてisFollowedというBool型の変数を追加し、ユーザーがfollowされているか否かを判別するようにしている