### PR TITLE
Feat/tweet likes

### DIFF
--- a/TwitterClone/API/TweetService.swift
+++ b/TwitterClone/API/TweetService.swift
@@ -84,4 +84,18 @@ struct TweetService {
             }
         }
     }
+    
+    func likeTweet(tweet: Tweet, completion: @escaping(DatabaseCompletion)){
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        
+        let likes = tweet.didLike ? tweet.likes - 1 : tweet.likes + 1
+        REF_TWEETS.child(tweet.tweetID).child("likes").setValue(likes)
+        
+        if tweet.didLike{
+            // remove like data from firebase (unlike tweet)
+        }else{
+            // add like data from firebse (like tweet)
+            REF_USER_LIKES.child(uid).updateChildValues([tweet.tweetID: 1], withCompletionBlock: completion)
+        }
+    }
 }

--- a/TwitterClone/API/TweetService.swift
+++ b/TwitterClone/API/TweetService.swift
@@ -103,4 +103,12 @@ struct TweetService {
             }
         }
     }
+    
+    func checkIfUserLikedTweet(_ tweet: Tweet, completion: @escaping(Bool) -> Void) {
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        
+        REF_USER_LIKES.child(uid).child(tweet.tweetID).observeSingleEvent(of: .value) { (snapshot) in
+            completion(snapshot.exists())
+        }
+    }
 }

--- a/TwitterClone/API/TweetService.swift
+++ b/TwitterClone/API/TweetService.swift
@@ -93,9 +93,14 @@ struct TweetService {
         
         if tweet.didLike{
             // remove like data from firebase (unlike tweet)
+            REF_USER_LIKES.child(uid).child(tweet.tweetID).removeValue { (err, ref) in
+                REF_TWEET_LIKES.child(tweet.tweetID).removeValue(completionBlock: completion)
+            }
         }else{
             // add like data from firebse (like tweet)
-            REF_USER_LIKES.child(uid).updateChildValues([tweet.tweetID: 1], withCompletionBlock: completion)
+            REF_USER_LIKES.child(uid).updateChildValues([tweet.tweetID: 1]) { (err, ref) in
+                REF_TWEET_LIKES.child(tweet.tweetID).updateChildValues([uid: 1], withCompletionBlock: completion)
+            }
         }
     }
 }

--- a/TwitterClone/Controllers/FeedController.swift
+++ b/TwitterClone/Controllers/FeedController.swift
@@ -43,6 +43,17 @@ class FeedController: UICollectionViewController{
     func fetchTweets(){
         TweetService.shared.fetchTweets { (tweets) in
             self.tweets = tweets
+            self.checkIfUSerLikedTweets(self.tweets)
+        }
+    }
+    
+    func checkIfUSerLikedTweets(_ tweets: [Tweet]){
+        for (index, tweet) in tweets.enumerated() {
+            TweetService.shared.checkIfUserLikedTweet(tweet) { (didLike) in
+                guard didLike == true else { return }
+                
+                self.tweets[index].didLike = true
+            }
         }
     }
     

--- a/TwitterClone/Controllers/FeedController.swift
+++ b/TwitterClone/Controllers/FeedController.swift
@@ -113,6 +113,14 @@ extension FeedController: UICollectionViewDelegateFlowLayout {
 //MARK: - TweetCellDelegate
 
 extension FeedController: TweetCellDelegate{
+    func handleLikeTapped(_ cell: TweetCell) {
+//        guard var tweet = cell.tweet else { return }
+        
+        cell.tweet?.didLike.toggle()
+        
+        print("DEBUG: Tweet is liked is \(cell.tweet?.didLike)")
+    }
+    
     func handleReplyTapped(_ cell: TweetCell) {
         guard let tweet = cell.tweet else { return }
         let controller = UploadTweetController(user: tweet.user, config: .reply(tweet))

--- a/TwitterClone/Controllers/FeedController.swift
+++ b/TwitterClone/Controllers/FeedController.swift
@@ -114,11 +114,13 @@ extension FeedController: UICollectionViewDelegateFlowLayout {
 
 extension FeedController: TweetCellDelegate{
     func handleLikeTapped(_ cell: TweetCell) {
-//        guard var tweet = cell.tweet else { return }
+        guard let tweet = cell.tweet else { return }
         
-        cell.tweet?.didLike.toggle()
-        
-        print("DEBUG: Tweet is liked is \(cell.tweet?.didLike)")
+        TweetService.shared.likeTweet(tweet: tweet) { (err, ref) in
+            cell.tweet?.didLike.toggle()
+            let likes = tweet.didLike ? tweet.likes - 1 : tweet.likes + 1
+            cell.tweet?.likes = likes
+        }
     }
     
     func handleReplyTapped(_ cell: TweetCell) {

--- a/TwitterClone/Model/Tweet.swift
+++ b/TwitterClone/Model/Tweet.swift
@@ -12,7 +12,7 @@ struct Tweet {
     let caption: String
     let tweetID: String
     let uid: String
-    let likes: Int
+    var likes: Int
     var timestamp: Date!
     let retweetCount: Int
     var user: User

--- a/TwitterClone/Model/Tweet.swift
+++ b/TwitterClone/Model/Tweet.swift
@@ -16,6 +16,7 @@ struct Tweet {
     var timestamp: Date!
     let retweetCount: Int
     var user: User
+    var didLike = false
     
     init(user: User, tweetID: String, dictionary: [String: Any]) {
         self.user = user

--- a/TwitterClone/Utils/Constants.swift
+++ b/TwitterClone/Utils/Constants.swift
@@ -19,3 +19,6 @@ let REF_USER_TWEETS = DB_REF.child("user-tweets")
 let REF_USER_FOLLOWERS = DB_REF.child("user-followers")
 let REF_USER_FOLLOWING = DB_REF.child("user-following")
 let REF_TWEET_REPLIES = DB_REF.child("tweet-replies")
+let REF_USER_LIKES = DB_REF.child("user-likes")
+let REF_TWEET_LIKES = DB_REF.child("tweet-likes")
+

--- a/TwitterClone/View/TweetCell.swift
+++ b/TwitterClone/View/TweetCell.swift
@@ -11,6 +11,7 @@ import UIKit
 protocol TweetCellDelegate: class{
     func handleProfileImageTapped(_ cell: TweetCell)
     func handleReplyTapped(_ cell: TweetCell)
+    func handleLikeTapped(_ cell: TweetCell)
 }
 
 
@@ -147,7 +148,7 @@ class TweetCell: UICollectionViewCell{
     }
     
     @objc func handleLikeTapped(){
-        
+        delegate?.handleLikeTapped(self)
     }
     
     @objc func handleShareTapped(){

--- a/TwitterClone/View/TweetCell.swift
+++ b/TwitterClone/View/TweetCell.swift
@@ -165,5 +165,7 @@ class TweetCell: UICollectionViewCell{
         profileImageView.sd_setImage(with: viewModel.profileImageUrl)
         infoLabel.attributedText = viewModel.userInfoText
         
+        likeButton.tintColor = viewModel.likeButtonTintColor
+        likeButton.setImage(viewModel.likeButtonImage, for: .normal)
     }
 }

--- a/TwitterClone/ViewModel/TweetViewModel.swift
+++ b/TwitterClone/ViewModel/TweetViewModel.swift
@@ -55,6 +55,16 @@ struct TweetViewModel {
         return title
     }
     
+    var likeButtonTintColor: UIColor {
+        return tweet.didLike ? .red : .lightGray
+    }
+    
+    var likeButtonImage: UIImage{
+        let imageName = tweet.didLike ? "like_filled" : "like"
+        return UIImage(named: imageName)!
+    }
+    
+    
     init(tweet: Tweet) {
         self.tweet = tweet
         self.user = tweet.user


### PR DESCRIPTION
tweetのlike機能を実装
tweetストラクチャーにて、当該ツイートを自分がlikeしたか否かを判定するdidLikeというプロパティを用意しているが、そのデータに関してはfirebase上に上げていない
そのため、checkifUserLikedTweetというカスタム関数にて、全ツイートから自分がlikeした,
つまりuser-likes.child(uid)が存在するツイートのみに、didLike = trueとする処理を行った
そこでは、for文を用いているが、そのfor文の使い方が面白かったのでまた後でどこかで試したい。
またguard文の使い方についても　guard didLike == true else { return }という使い方も初めてみたので、またどこかでまとめる